### PR TITLE
Show rule lookup by number failure only to sender

### DIFF
--- a/src/features/commands/rules.js
+++ b/src/features/commands/rules.js
@@ -39,6 +39,7 @@ module.exports = {
                             data: {
                                 type: 4,
                                 data: {
+                                    flags: 64,
                                     content: `Rule ${interaction.data.options[0].options[0].value} does not exist, there are ${fetchedRules.form_fields[0].values.length} rules defined in this community.`
                                 },
                             },


### PR DESCRIPTION
When using the `/rules rule [number]` command, and you give an invalid rule number (eg. `-1`) or one that exceeds the number of rules, the message will be visibe to all users on the server.

All other command on failure send the message only to you, such as the command `/rules search keyword: "not in rules"`.

This PR just adds the required flag to the message that gets sent when a rule from the id/number can't be found.

The correct flag number was taken from

https://github.com/Microsoft-community/Dotsimus/blob/6a830b73e38017311b17618fab533b6badf0bde8/src/features/commands/rules.js#L76-L77