### PR TITLE
Minimal implementation of the report system

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@discordjs/rest": "^0.1.0-canary.0",
     "@sentry/node": "6.11.0",
+    "@top-gg/sdk": "^3.1.2",
+    "async-mutex": "^0.3.1",
     "chalk": "^4.1.2",
     "discord-api-types": "^0.22.0",
     "discord.js": "^13.1.0",
@@ -21,7 +23,6 @@
     "lodash": "^4.17.21",
     "mongoose": "^5.13.7",
     "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
-    "@top-gg/sdk": "^3.1.2"
+    "request-promise-native": "^1.0.9"
   }
 }

--- a/src/db/schemas/blockedReport.js
+++ b/src/db/schemas/blockedReport.js
@@ -1,0 +1,6 @@
+const mongoose = require('mongoose')
+
+module.exports = new mongoose.Schema({
+    userId: Number,
+    userName: String
+})

--- a/src/features/commands/ban.js
+++ b/src/features/commands/ban.js
@@ -1,0 +1,52 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+    type: 'slash',
+    data: new SlashCommandBuilder()
+        .setName('ban')
+        .setDescription('Bans user from the server.')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('Select user to ban.')
+                .setRequired(true)
+        )
+        .addStringOption(option =>
+            option.setName('reason')
+                .setDescription('Reason for a ban.')
+                .setRequired(false)
+        ),
+    async execute (client, interaction) {
+        await interaction.deferReply();
+        const userSnowflake = interaction.options.getUser('user');
+        if (interaction.member.permissions.serialize().BAN_MEMBERS) {
+            if (!isNaN(userSnowflake)) {
+                const reason = interaction.options.get('reason')?.value ?? "No reason specified.";
+                interaction.guild.members.ban(userSnowflake, { reason: interaction.options.get('reason')?.value })
+                if (!interaction.options.get('reason')?.value) {
+                    interaction.editReply({
+                        type: 4,
+                        content: `${userSnowflake} has been banned.`
+                    });
+                } else {
+                    interaction.editReply({
+                        type: 4,
+                        content: `${userSnowflake} has been banned for **${reason}.**`
+                    });
+                }
+            } else {
+                interaction.editReply({
+                    type: 4,
+                    ephemeral: true,
+                    content: `⚠️ Invalid user specified, double check whether user ID is correct.`
+                })
+            }
+        } else {
+            interaction.editReply({
+                type: 4,
+                ephemeral: true,
+                content: `You don't have required permissions to run this command.`
+            })
+
+        }
+    },
+}

--- a/src/features/commands/buttons/modMessageApproveReport.js
+++ b/src/features/commands/buttons/modMessageApproveReport.js
@@ -1,0 +1,47 @@
+const { User } = require('discord.js'),
+    db = require('../../../db');
+
+const Reports = require('../../../reportObject');
+const MessageReports = require('../../../reportTypes/message');
+
+module.exports = {
+    name: 'modMessageApproveReport',
+    type: 'button',
+    description: 'Notify all reporters that this report is a valid one',
+    async execute (client, interaction) {
+        interaction.deferUpdate();
+
+        let reportData;
+        try {
+            reportData = await MessageReports.Storage.findByGeneratedReport(client, interaction.message);
+        } catch(e) {
+            await interaction.reply({
+                content: e.message
+            });
+            return;
+        }
+
+        reportObject = MessageReports.parseReport(client, reportData);
+
+        for (let i = 0; i < reportObject.signalers.length; i++) {
+            sendApprovalDM(reportObject.signalers[i]);
+        }
+
+        reportObject.status = Reports.ReportStatus.Approved;
+        reportObject.reportedUser = await reportObject.reportedUser.fetch();
+        reportObject.acceptor = interaction.member;
+        reportObject.reportedContent.approve();
+
+        await reportObject.investigation.edit({
+            embeds: [ Reports.ReportEmbed.createModeratorReportEmbed(reportObject) ],
+            components: []
+        });
+    }
+};
+
+async function sendApprovalDM(user) {
+    const DM = await user.createDM();
+    await DM.send({
+        content: 'The moderation team has reviewed your report and took appropriate actions. The reported content was found to be against the server rules, we thank you for your report'
+    });
+}

--- a/src/features/commands/buttons/modMessageRejectReport.js
+++ b/src/features/commands/buttons/modMessageRejectReport.js
@@ -1,0 +1,48 @@
+const { Client } = require('discord.js'),
+    db = require('../../../db');
+
+const Reports = require('../../../reportObject');
+const MessageReports = require('../../../reportTypes/message');
+
+module.exports = {
+    name: 'modMessageRejectReport',
+    type: 'button',
+    description: 'Reject and notify all reporters that no action will be taken',
+    async execute (client, interaction) {
+        interaction.deferUpdate();
+
+        let reportData;
+        try {
+            reportData = await MessageReports.Storage.findByGeneratedReport(client, interaction.message);
+        } catch(e) {
+            await interaction.reply({
+                content: e.message
+            });
+            return;
+        }
+
+        reportedContent = MessageReports.ReportedMessage.fromJSON(reportData.reportedContent);
+        reportObject = MessageReports.parseReport(client, reportData);
+
+        for (let i = 0; i < reportObject.signalers.length; i++) {
+            sendRejectDM(reportObject.signalers[i]);
+        }
+
+        reportObject.status = Reports.ReportStatus.Rejected;
+        reportObject.reportedUser = await reportObject.reportedUser.fetch();
+        reportObject.acceptor = interaction.member;
+
+        await reportObject.investigation.edit({
+            embeds: [ Reports.ReportEmbed.createModeratorReportEmbed(reportObject) ],
+            components: []
+        });
+    }
+};
+
+async function sendRejectDM(user) {
+    const DM = await user.createDM();
+    await DM.send({
+        content: 'Following your report, the moderation team has estimated that the message is not against the server rules.\n'
+            + 'If you think this is an error, please contact a moderator through the moderation mail.'
+    });
+}

--- a/src/features/commands/report.js
+++ b/src/features/commands/report.js
@@ -21,7 +21,7 @@ function getMessageId(linkOrId)
 }
 
 // Minimum time before allowing the user to report
-const reportAwaitTime = 1000;
+const reportAwaitTime = 5000;
 // Time before dropping the report. This is used to avoid users create many interactions that the bot collects.
 const reportTimeout = 30000;
 

--- a/src/features/commands/report.js
+++ b/src/features/commands/report.js
@@ -1,0 +1,120 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageActionRow, MessageButton } = require('discord.js');
+const { report } = require('process');
+const { promisify } = require('util')
+const Report = require('../../reportObject.js');
+const UserCases = require('../../userCases.js');
+
+function getMessageId(linkOrId)
+{
+    if (!isNaN(linkOrId)) {
+        return linkOrId;
+    } else {
+        const match = linkOrId.match('/discord.com/channels/([0-9]+)/([0-9]+)/([0-9]+)');
+        return match[3];
+    }
+}
+
+module.exports = {
+    type: 'slash',
+    data: new SlashCommandBuilder()
+        .setName('report')
+        .setDescription('Reports a message')
+        .addStringOption(option =>
+            option.setName('message')
+                .setDescription('Message link, or message ID')
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('reason')
+                .setDescription('The reason of the report')
+                .setRequired(false)),
+
+    async execute(client, interaction)
+    {
+        reason = interaction.options.getString('reason');
+        messageLinkOrId = interaction.options.get('message').value;
+
+        try
+        {
+            // try to get the message id from the link
+            const messageId = getMessageId(messageLinkOrId);
+            message = await interaction.channel.messages.fetch(messageId);
+        }
+        catch(e)
+        {
+            interaction.reply({
+                content: 'Please input a valid Discord message link, or a valid message ID',
+                ephemeral: true
+            });
+            return;
+        }
+
+        try
+        {
+            const report = await reportMessage(interaction.member, message, reason);
+
+            await sendReport(client, report);
+
+            if (report.signalers.length <= 1)
+            {
+                interaction.reply({
+                    content: `Your report was successfully created. Report #${report.id}. The reported user: ${report.reportedContent.author}`,
+                    ephemeral: true
+                });
+            }
+            else
+            {
+                // one or more users reported before us
+                interaction.reply({
+                    content: `The report already exists but was boosted.  Report #${report.id}. The reported user: ${report.reportedContent.author}`,
+                    ephemeral: true
+                });
+            }
+        }
+        catch(e)
+        {
+            interaction.reply({
+                content: 'Report creation failed: ' + e,
+                ephemeral: true
+            });
+        }
+    }
+}
+
+async function reportMessage(member, message, reason) {
+    // create a new message-related report
+    const reportedContent = new Report.ReportedMessage(message);
+    const report = new Report.ReportObject(
+        message.guild,
+        member,
+        reason,
+        reportedContent,
+        message.author
+    );
+
+    report.id = 12345;
+    return report;
+}
+
+async function sendReport(client, reportObject) {
+    const embed = Report.ReportEmbed.createModeratorReportEmbed(reportObject);
+    const components = [
+        new MessageActionRow()
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('reportApprovalAction')
+                    .setLabel('Approve')
+                    .setStyle('PRIMARY')
+            )
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('reportRejectionAction')
+                    .setLabel('Reject')
+                    .setStyle('DANGER')
+            )
+    ];
+
+    userCase = await UserCases.getOrCreateCase(client, reportObject.guild, reportObject.reportedUser, embed, components, 'New report');
+    reportObject.thread = userCase.thread;
+    reportObject.investigation = userCase.message;
+}

--- a/src/features/commands/report.js
+++ b/src/features/commands/report.js
@@ -1,10 +1,14 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { MessageActionRow, MessageButton } = require('discord.js');
+const { MessageActionRow, MessageButton, MessageSelectMenu, MessageSelectOptionData, Constants, MessageEmbed } = require('discord.js');
 const { report } = require('process');
 const { promisify } = require('util')
 const Report = require('../../reportObject.js');
 const UserCases = require('../../userCases.js');
 const db = require('../../db');
+const { fetchRules } = require('./../../api/discord-gating');
+const { values } = require('lodash');
+const wait = promisify(setTimeout);
+const MessageReports = require('../../reportTypes/message.js');
 
 function getMessageId(linkOrId)
 {
@@ -16,107 +20,321 @@ function getMessageId(linkOrId)
     }
 }
 
+// Minimum time before allowing the user to report
+const reportAwaitTime = 1000;
+// Time before dropping the report. This is used to avoid users create many interactions that the bot collects.
+const reportTimeout = 30000;
+
+const alreadyReportedText = 'You already reported this message.';
+const alreadyReviewedText = 'This report was already reviewed by a moderator.';
+const blockedReportingText = `You are prevented from reporting, this could be because you abused the system.\n
+If you want more info, or if you think this is an error, contact moderators.`;
+const warnText = 'You are about to report a message. Abusing the report system coud lead to punishment. If this is really your intent you can go ahead.';
+const genericReportText = 'Moderators will now review your report. Please note that they are not robots: it might take some time before an action is taken. You will receive a DM once moderators review your report, make sure you have enabled them for this server!';
+
+// map of current report challenges by user
+const userReportMap = new Map();
+
 module.exports = {
-    type: 'slash',
-    data: new SlashCommandBuilder()
-        .setName('report')
-        .setDescription('Reports a message')
-        .addStringOption(option =>
-            option.setName('message')
-                .setDescription('Message link, or message ID')
-                .setRequired(true))
-        .addStringOption(option =>
-            option.setName('reason')
-                .setDescription('The reason of the report')
-                .setRequired(false)),
+    type: 'app',
+    data: {
+        name: 'Report',
+        type: Constants.ApplicationCommandTypes.MESSAGE,
+        defaultPermission: true
+    },
 
     async execute(client, interaction) {
-        if (await db.usedPreventedFromReport(interaction.member.id)) {
+        if (!await canReport(interaction.user)) {
             return await interaction.reply({
-                content: `You are prevented from reporting, this could be because you abused the system.\n
-                If you want more info, or if you think this is an error, contact moderators.`,
+                content: blockedReportingText,
                 ephemeral: true
             });
         }
 
-        reason = interaction.options.getString('reason');
-        messageLinkOrId = interaction.options.get('message').value;
+        const reportedMessage = interaction.options.getMessage('message');
 
+        let challenge;
         try {
-            // try to get the message id from the link
-            const messageId = getMessageId(messageLinkOrId);
-            message = await interaction.channel.messages.fetch(messageId);
+            // create a report challenge to prevent users from creating multiple interactions for the same message
+            challenge = createUniqueChallenge(interaction.user, reportedMessage);
         } catch(e) {
-            interaction.reply({
-                content: 'Please input a valid Discord message link, or a valid message ID',
+            let error;
+            if (e.message === 'already_exists') {
+                error = 'You are already making a report for this message.';
+            } else {
+                error = e.message;
+            }
+
+            return await interaction.reply({
+                content: error,
                 ephemeral: true
             });
-            return;
         }
 
         try {
-            const report = await reportMessage(interaction.member, message, reason);
-
-            await sendReport(client, report);
-
-            if (report.signalers.length <= 1)
-            {
-                interaction.reply({
-                    content: `Your report was successfully created. Report #${report.id}. The reported user: ${report.reportedContent.author}`,
+            const reportData = await MessageReports.findReport(client, reportedMessage);
+            if (reportData) {
+                removeChallenge(challenge);
+            }
+            
+            if (reportData.status === Report.ReportStatus.Pending) {
+                return await interaction.reply({
+                    content: alreadyReportedText,
+                    ephemeral: true
+                });
+            } else {
+                return await interaction.reply({
+                    content: alreadyReviewedText,
                     ephemeral: true
                 });
             }
-            else
-            {
-                // one or more users reported before us
-                interaction.reply({
-                    content: `The report already exists but was boosted.  Report #${report.id}. The reported user: ${report.reportedContent.author}`,
-                    ephemeral: true
-                });
-            }
         } catch(e) {
-            interaction.reply({
-                content: 'Report creation failed: ' + e,
-                ephemeral: true
-            });
+            // no existing report found
         }
+
+        const rules = await fetchRules(interaction.guild.id);
+
+        const awaitTimeSeconds = Math.floor(reportAwaitTime / 1000);
+        await interaction.reply({
+            embeds: [ generateChallengeEmbed(challenge, `${warnText}\nYou will be allowed to report in ${awaitTimeSeconds} seconds.`) ],
+            ephemeral: true
+        });
+
+        // give the user a chance to read
+        await wait(reportAwaitTime);
+
+        const filter = (i) => {
+            if (i.user.id !== interaction.user.id) {
+                return false;
+            }
+
+            if (!i.message.embeds || !i.message.embeds[0].footer) {
+                return false;
+            }
+
+            const list = i.message.embeds[0].footer.text.split(' ');
+            const foundChallenge = list[0];
+            const foundMessage = list[1];
+
+            return foundChallenge == challenge.id && foundMessage == reportedMessage.id;
+        };
+
+        const cleanup = () => {
+            collector.removeAllListeners();
+            collector.stop('canceled');
+            removeChallenge(challenge);
+        };
+    
+        const collector = interaction.channel.createMessageComponentCollector({
+            filter,
+            time: reportTimeout
+        });
+
+        ruleList = [];
+
+        collector.on('collect', async i => {
+            if (i.customId === 'user_report_reason') {
+                ruleList = i.values;
+                i.deferUpdate();
+            } else if (i.customId === 'user_report_cancel') {
+                cleanup();
+
+                await interaction.editReply({
+                    embeds: [ generateChallengeEmbed(null, `${warnText}`) ],
+                    components: []
+                });
+
+                await interaction.followUp({
+                    embeds: [ generateChallengeEmbed(null, 'The operation was canceled by the user.') ],
+                    ephemeral: true
+                })
+            }
+        });
+
+        collector.on('end', async (collected, reason) => {
+            await interaction.editReply({
+                embeds: [ generateChallengeEmbed(null, `${warnText}`) ],
+                components: []
+            });
+
+            await interaction.followUp({
+                embeds: [ generateChallengeEmbed(null, 'Message not reported in the mean time.') ],
+                ephemeral: true
+            })
+        });
+
+        collector.on('collect', i => {
+            if (i.customId === 'user_report_accept') {
+                if (!ruleList.length) {
+                    i.reply({
+                        content: 'Please select one or more rules.',
+                        ephemeral: true
+                    });
+                } else {
+                    cleanup();
+
+                    interaction.editReply({
+                        embeds: [ generateChallengeEmbed(null, `${warnText}`) ],
+                        components: []
+                    });
+
+                    handleSendReport(client, i, reportedMessage, ruleList.sort());
+                }
+            }
+        })
+
+        const timeoutSeconds = Math.floor(reportTimeout / 1000);
+        await interaction.editReply({
+            embeds: [ generateChallengeEmbed(challenge, `${warnText}\n${timeoutSeconds} seconds before the report expires.`) ],
+            components: createReportComponents(rules, false)
+        });
     }
 }
 
-async function reportMessage(member, message, reason) {
-    // create a new message-related report
-    const reportedContent = new Report.ReportedMessage(message);
-    const report = new Report.ReportObject(
-        message.guild,
-        member,
-        reason,
-        reportedContent,
-        message.author
-    );
-
-    report.id = 12345;
-    return report;
+module.exports.data.toJSON = function () {
+    return module.exports.data;
 }
 
-async function sendReport(client, reportObject) {
-    const embed = Report.ReportEmbed.createModeratorReportEmbed(reportObject);
-    const components = [
+function createUniqueChallenge(user, message) {
+    let userReport = userReportMap.get(user.id);
+    if (userReport) {
+        const reportingMessage = userReport.current.get(message.id);
+        if (reportingMessage) {
+            throw new Error('already_exists');
+        }
+    } else {
+        userReport = {
+            user: user,
+            current: new Map(),
+            count: 0
+        };
+
+        userReportMap.set(user.id, userReport);
+    }
+
+    userReport.count++;
+    userReport.current.set(message.id, message);
+    return {
+        id: userReport.count,
+        userReport,
+        messageId: message.id
+    };
+}
+
+async function canReport(user) {
+    return !await db.usedPreventedFromReport(user.id);
+}
+
+function removeChallenge(challenge) {
+    challenge.userReport.current.delete(challenge.messageId);
+    if (!challenge.userReport.current.size) {
+        // if there is no pending report for the user, no need to keep track of them
+        userReportMap.delete(challenge.userReport.user.id);
+    }
+}
+
+function generateChallengeEmbed(challenge, text) {
+    const footer = challenge ? `${challenge.id} ${challenge.messageId}` : '';
+
+    return new MessageEmbed()
+        .setTitle('Report')
+        .setDescription(text)
+        .setFooter(footer);
+}
+
+function buildSelectMenu(rules) {
+    selects = [];
+    rules.form_fields[0].values.forEach((element, index) => {
+        const ruleNum = index + 1;
+        selects.push({
+            label: `Rule #${ruleNum}`,
+            value: `${ruleNum}`,
+            description: `${element.substring(0, 50)}...`
+        });
+    });
+
+    return selects;
+}
+
+function createReportComponents(rules, shouldDisable) {
+    return [
+        new MessageActionRow()
+            .addComponents(
+                new MessageSelectMenu()
+                    .setCustomId('user_report_reason')
+                    .setMinValues(1)
+                    .setMaxValues(3)
+                    .addOptions(buildSelectMenu(rules))
+            ),
         new MessageActionRow()
             .addComponents(
                 new MessageButton()
-                    .setCustomId('reportApprovalAction')
-                    .setLabel('Approve')
-                    .setStyle('PRIMARY')
-            )
-            .addComponents(
+                    .setCustomId('user_report_accept')
+                    .setLabel('Accept')
+                    .setStyle('SUCCESS')
+                    .setDisabled(shouldDisable),
                 new MessageButton()
-                    .setCustomId('reportRejectionAction')
-                    .setLabel('Reject')
+                    .setCustomId('user_report_cancel')
+                    .setLabel('Cancel')
                     .setStyle('DANGER')
             )
     ];
+}
 
-    userCase = await UserCases.getOrCreateCase(client, reportObject.guild, reportObject.reportedUser, embed, components, 'New report');
-    reportObject.thread = userCase.thread;
-    reportObject.investigation = userCase.message;
+function createReportText(ruleList) {
+    if (ruleList.length <= 1) {
+        return `You have selected rule #${ruleList[0]}.`;
+    } else {
+        ruleText = "";
+        ruleList.forEach((element, index) => {
+            if (index) {
+                if (index < ruleList.length - 1) {
+                    ruleText += ', ';
+                } else {
+                    ruleText += ' and ';
+                }
+            }
+            ruleText += `#${element}`;
+        });
+
+        return `You have selected rules ${ruleText}.`;
+    }
+}
+
+async function handleSendReport(client, interaction, message, ruleList) {
+    let report;
+    try {
+        report = await MessageReports.report(client, interaction.member, message, ruleList);
+    } catch(e) {
+        let error;
+        switch(e.message)
+        {
+            case 'already_reported':
+                error = alreadyReportedText;
+                break;
+            case 'already_reviewed':
+                error = alreadyReviewedText;
+                break;
+            default:
+                error = 'Failed to send the report to moderators.';
+                console.error(e);
+                // NOTE: should it disclose the error to users?
+                break;
+        }
+
+        interaction.reply({
+            content: error,
+            ephemeral: true
+        });
+        console.error(e);
+        return;
+    }
+
+    const embed = Report.ReportEmbed.createBasicReportEmbed(report);
+
+    interaction.reply({
+        content: `${createReportText(ruleList)}. ${genericReportText} Your report:`,
+        embeds: [embed],
+        ephemeral: true
+    });
 }

--- a/src/features/commands/reportMod.js
+++ b/src/features/commands/reportMod.js
@@ -1,0 +1,52 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const db = require('../../db');
+
+module.exports = {
+    type: 'slash',
+    data: new SlashCommandBuilder()
+        .setName('reportmod')
+        .setDescription('Manage reports')
+        .addSubcommand(command =>
+            command
+                .setName('block')
+                .setDescription('Block an user from using report commands')
+                .addUserOption(option =>
+                    option
+                        .setName('user')
+                        .setDescription('User to block')
+                        .setRequired(true)))
+        .addSubcommand(command =>
+            command
+                .setName('unblock')
+                .setDescription('Reallow an user to use report commands')
+                .addUserOption(option =>
+                    option
+                        .setName('user')
+                        .setDescription('User to block')
+                        .setRequired(true))),
+
+    async execute(client, interaction) {
+        switch(interaction.options.getSubcommand()) {
+            case 'block': {
+                const user = interaction.options.getUser('user');
+    
+                await db.saveBlockedReportUser(user.id, user.username);
+        
+                interaction.reply({
+                    content: `:exclamation: The user ${user} is now blocked from using report commands.`,
+                    ephemeral: true
+                })
+            } break;
+            case 'unblock': {
+                const user = interaction.options.getUser('user');
+    
+                await db.deleteBlockedReportUser(user.id);
+        
+                interaction.reply({
+                    content: `:white_check_mark: The user ${user} can now use report commands.`,
+                    ephemeral: true
+                })
+            } break;
+        }
+    }
+}

--- a/src/features/commands/unban.js
+++ b/src/features/commands/unban.js
@@ -1,0 +1,37 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('unban')
+        .setDescription('Unbans user from the server.')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('Select user to unban.')
+                .setRequired(true)
+        ),
+    async execute (client, interaction) {
+        await interaction.deferReply();
+        const userSnowflake = interaction.options.getUser('user');
+        if (interaction.member.permissions.serialize().BAN_MEMBERS) {
+            if (!isNaN(userSnowflake)) {
+                interaction.guild.members.unban(userSnowflake).catch(() => {});
+                interaction.editReply({
+                    type: 4,
+                    content: `${userSnowflake} has been unbanned successfully.`
+                });
+            } else {
+                interaction.editReply({
+                    type: 4,
+                    ephemeral: true,
+                    content: `⚠️ Invalid user specified, try double check whether user ID is correct.`
+                })
+            }
+        } else {
+            interaction.editReply({
+                type: 4,
+                ephemeral: true,
+                content: `You don't have enough permissions to run this command.`
+            })
+        }
+    },
+}

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,8 @@ const Sentry = require('@sentry/node'),
   { REST } = require('@discordjs/rest'),
   { Routes } = require('discord-api-types/v9'),
   commandsArray = [],
-  devClientId = '880151909623791668',
-  devGuildId = '880152553847930940';
+  devClientId = '793068568601165875',
+  devGuildId = '280600603741257728';
 
 
 for (const file of commandFiles) {
@@ -35,7 +35,7 @@ const rest = new REST({ version: '9' }).setToken(process.env.DEVELOPMENT !== 'tr
   try {
     console.info('Started refreshing application slash commands.');
     await rest.put(
-      process.env.DEVELOPMENT !== 'true' ? Routes.applicationCommands('880151909623791668') : Routes.applicationGuildCommands(devClientId, devGuildId),
+      process.env.DEVELOPMENT !== 'true' ? Routes.applicationCommands('731190736996794420') : Routes.applicationGuildCommands(devClientId, devGuildId),
       { body: commandsArray },
     );
     console.info('Successfully reloaded application slash commands.');

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,8 @@ const Sentry = require('@sentry/node'),
   { REST } = require('@discordjs/rest'),
   { Routes } = require('discord-api-types/v9'),
   commandsArray = [],
-  devClientId = '793068568601165875',
-  devGuildId = '280600603741257728';
+  devClientId = '880151909623791668',
+  devGuildId = '880152553847930940';
 
 
 for (const file of commandFiles) {
@@ -35,7 +35,7 @@ const rest = new REST({ version: '9' }).setToken(process.env.DEVELOPMENT !== 'tr
   try {
     console.info('Started refreshing application slash commands.');
     await rest.put(
-      process.env.DEVELOPMENT !== 'true' ? Routes.applicationCommands('731190736996794420') : Routes.applicationGuildCommands(devClientId, devGuildId),
+      process.env.DEVELOPMENT !== 'true' ? Routes.applicationCommands('880151909623791668') : Routes.applicationGuildCommands(devClientId, devGuildId),
       { body: commandsArray },
     );
     console.info('Successfully reloaded application slash commands.');
@@ -216,7 +216,7 @@ client.on('messageCreate', message => {
       });
     })
   })
-  if (server.isPremium && !(message.member.permissions.serialize().KICK_MEMBERS || message.member.permissions.serialize().BAN_MEMBERS || message.member.roles.cache.some(role => role.id === '332343869163438080'))) {
+  if (!(message.member.permissions.serialize().KICK_MEMBERS || message.member.permissions.serialize().BAN_MEMBERS || message.member.roles.cache.some(role => role.id === '332343869163438080'))) {
   // if (server.isPremium) {
     getToxicity(message.content, message, false).then(toxicity => {
       // console.info(`${getTime()} #${message.channel.name} ${message.author.username}: ${message.content} | ${chalk.red((Number(toxicity.toxicity) * 100).toFixed(2))} ${chalk.red((Number(toxicity.insult) * 100).toFixed(2))}`)

--- a/src/reportObject.js
+++ b/src/reportObject.js
@@ -1,0 +1,153 @@
+const { MessageEmbed } = require('discord.js');
+
+const ReportStatus = {
+    Pending: 'Pending',
+    Validated: 'Validated',
+    Rejected: 'Rejected'
+};
+
+class ReportedContentInterface {
+    constructor() {
+        this.reportType = "Unknown";
+        this.link = "";
+    }
+
+    /**
+     * Returns whether or not the content is the same or has changed since then
+     * @returns True if same.
+     */
+    isSame() {
+        throw "unimplemented";
+        return false;
+    }
+
+    /**
+     * Called when the report has been approved.
+     */
+    approve() {
+        throw "unimplemented";
+    }
+
+    /**
+     * Returns the content text to display.
+     * @returns content string.
+     */
+    getContent() {
+        throw "unimplemented";
+        return "";
+    }
+}
+
+class ReportedMessage extends ReportedContentInterface {
+    constructor(message) {
+        super(message);
+
+        this.reportType = "Message";
+        this.message = message;
+        this.link = message.url;
+        this.content = message.content;
+    }
+
+    isSame() {
+        return this.content == this.message.content;
+    }
+
+    approve() {
+        // approving will delete the message
+        try
+        {
+            this.message.delete();
+        }
+        catch(e)
+        {
+            // if the bot doesn't have right to delete the message
+            // then maybe let moderators delete it
+        }
+    }
+
+    getContent() {
+        // return the content at the time of the report
+        return this.content;
+    }
+}
+
+class ReportObject {
+    constructor(guild, author, reason, content, reportedUser) {
+        this.id = 0;
+        this.guild = guild;
+        this.owner = author;
+        this.reportedContent = content;
+        this.reportedUser = message.author;
+        this.signalers = [ author ];
+        this.reason = reason;
+        this.investigation = 0;
+        this.thread = 0;
+        this.status = ReportStatus.Pending;
+        this.acceptor = 0;
+        this.actionTaken = null;
+    }
+
+    setOwner(user) {
+        this.owner = user;
+        this.signalers = [ user ];
+    }
+
+    boost(user) {
+        this.signalers.push(user);
+    }
+}
+
+class ReportEmbed {
+    static createBasicReportEmbed(reportObject) {
+        let embed = new MessageEmbed()
+            .setTitle(`Report ${reportObject.id}`)
+            .setAuthor(reportObject.reportedUser.tag, reportObject.reportedUser.displayAvatarURL())
+            .addFields(
+                { name: 'User ID', value: reportObject.reportedUser.toString() },
+                { name: 'Type', value: reportObject.reportedContent.reportType }
+            );
+
+        if (reportObject.reason) {
+            embed = embed.addFields(
+                { name: 'Reason', value: reportObject.reason, inline: true }
+            );
+        }
+
+        embed = embed.addFields(
+            { name: 'Content', value: reportObject.reportedContent.getContent() },
+            { name: 'Context link', value: reportObject.reportedContent.link }
+        );
+
+        return embed;
+    }
+
+    static createModeratorReportEmbed(reportObject) {
+        let embed = ReportEmbed.createBasicReportEmbed(reportObject)
+            .addFields(
+                { name: 'ID', value: reportObject.id.toString(), inline: true },
+                { name: 'Status', value: reportObject.status, inline: true },
+                { name: 'Reported by', value: reportObject.owner.toString(), inline: true }
+            );
+
+        if (reportObject.status != ReportStatus.Pending) {
+            if (reportObject.acceptor != null) {
+                embed = embed.addFields(
+                    { name: 'Reviewed by', value: reportObject.acceptor }
+                );
+            }
+
+            if (reportObject.actionTaken != null) {
+                embed = embed.addFields(
+                    { name: 'Action taken', value: reportObject.actionTaken }
+                );
+            }
+        }
+
+        return embed;
+    }
+};
+
+module.exports.ReportObject = ReportObject;
+module.exports.ReportStatus = ReportStatus;
+module.exports.ReportedMessage = ReportedMessage;
+module.exports.ReportEmbed = ReportEmbed;

--- a/src/reportTypes/message.js
+++ b/src/reportTypes/message.js
@@ -1,0 +1,150 @@
+const Report = require('../reportObject.js');
+const Storage = require('./storage/messageStorageDiscord.js');
+const { Mutex, MutexInterface } = require('async-mutex');
+const { MessageActionRow, MessageButton, User, ThreadChannel, Message, Guild } = require('discord.js');
+const UserCases = require('../userCases.js');
+
+class ReportedMessage extends Report.ReportedContentInterface {
+    constructor(message) {
+        super(message);
+
+        this.reportType = 'Message';
+        this.message = message;
+        this.link = message.url;
+        this.content = message.content;
+
+        this.fields = {
+            'Message ID': `${message.id}`
+        };
+    }
+
+    static fromJSON(data) {
+        const reportedContent = new ReportedMessage({
+            id: data.message.id,
+            url: data.link,
+            content: data.content
+        });
+
+        return reportedContent;
+    }
+
+    isSame() {
+        return this.content == this.message.content;
+    }
+
+    approve() {
+        // approving will delete the message
+        try
+        {
+            this.message.delete();
+        }
+        catch(e)
+        {
+            // if the bot doesn't have right to delete the message
+            // then maybe let moderators delete it
+        }
+    }
+
+    getContent() {
+        // return the content at the time of the report
+        return this.content;
+    }
+}
+
+const messageMutex = new Mutex();
+
+module.exports = {
+    parseReport(client, reportData) {
+        const reportObject = new Report.ReportObject(
+            new Guild(client, { id: reportData.guildId }),
+            new User(client, { id: reportData.ownerId }),
+            reportData.reason,
+            ReportedMessage.fromJSON(reportData.reportedContent),
+            new User(client, { id: reportData.reportedUserId })
+        );
+
+        reportObject.signalers = [];
+
+        reportData.signalersId.forEach((id) => {
+            reportObject.signalers.push(new User(client, { id }));
+        });
+
+        reportObject.thread = new ThreadChannel(reportObject.guild, { id: reportData.threadId }, client);
+        reportObject.investigation = new Message(client, { id: reportData.investigationId });
+        reportObject.investigation.channelId = reportObject.thread.id;
+
+        return reportObject;
+    },
+    async findOrCreateReport(client, member, message, reason) {
+        const reportedContent = new ReportedMessage(message);
+
+        let reportData;
+        try {
+            reportData = await Storage.findByContentId(client, member.guild, message.author, message.id);
+        } catch(e) {
+            // create a new message-related report
+            return new Report.ReportObject(
+                message.guild,
+                member,
+                reason,
+                reportedContent,
+                message.author
+            );
+        }
+
+        if (reportData.status !== Report.ReportStatus.Pending) {
+            throw new Error('already_reviewed');
+        }
+
+        const existingMember = reportData.signalersId.find(id => id === member.id);
+        //if (existingMember) throw new Error('already_reported');
+
+        const reportObject = this.parseReport(client, reportData);
+        // boost by adding the new member
+        reportObject.signalers.push(member);
+        reportObject.reportedUser = await reportObject.reportedUser.fetch(false);
+
+        return reportObject;
+    },
+    async findReport(client, message) {
+        const reportData = await Storage.findByContentId(client, message.guild, message.author, message.id);
+        return reportData;
+    },
+    async report(client, member, message, reason) {
+        const reportObject = await this.findOrCreateReport(client, member, message, reason);
+
+        const embed = Report.ReportEmbed.createModeratorReportEmbed(reportObject);
+        const components = [
+            new MessageActionRow()
+                .addComponents(
+                    new MessageButton()
+                        .setCustomId('modMessageApproveReport')
+                        .setLabel('Approve')
+                        .setStyle('PRIMARY')
+                )
+                .addComponents(
+                    new MessageButton()
+                        .setCustomId('modMessageRejectReport')
+                        .setLabel('Reject')
+                        .setStyle('DANGER')
+                )
+        ];
+
+        let userCase;
+        if (!reportObject.investigation) {
+            userCase = await UserCases.createCase(client, reportObject.guild, reportObject.reportedUser, embed, components, 'New report');
+        } else {
+            userCase = await UserCases.modifyCase(reportObject.investigation, embed, components);
+        }
+    
+        reportObject.thread = userCase.thread;
+        reportObject.investigation = userCase.message;
+
+        await Storage.store(reportObject);
+
+        return reportObject;
+    }
+}
+
+module.exports.Storage = Storage;
+module.exports.ReportedMessage = ReportedMessage;

--- a/src/reportTypes/storage/messageStorageDiscord.js
+++ b/src/reportTypes/storage/messageStorageDiscord.js
@@ -1,0 +1,81 @@
+const UserCases = require('../../userCases.js');
+const Report = require('../../reportObject.js');
+
+module.exports.findByContentId = async function findByContentId(client, guild, user, id) {
+    const channel = await UserCases.getChannelForCases(client, guild);
+    const thread = await UserCases.findThreadCase(channel, user);
+
+    const messages = await thread.messages.fetch({ limit: 50 });
+    // filter messages created by the bot
+    message = messages.find(m => {
+        if (!m.embeds || !m.embeds.length) return false;
+        if (m.embeds.length > 1) return false;
+
+        const embed = m.embeds[0];
+        if (!embed.fields) return false;
+        const messageId = embed.fields.find(f => f.name === 'Message ID' && f.value == id);
+        return messageId !== undefined;
+    });
+
+    if (message) {
+        return parseMessage(message);
+    } else {
+        throw new Error('report not found');
+    }
+
+    return undefined;
+};
+
+module.exports.findByGeneratedReport = async function findByGeneratedReport(client, message) {
+    return parseMessage(message);
+}
+
+module.exports.store = async function store(client, guild, user, id) {
+    // this function doesn't make effect because this storage uses Discord
+}
+
+function parseMessage(message) {
+    const embed = message.embeds[0];
+    const messageId = embed.fields.find(f => f.name === 'Message ID');
+
+    const reportersField = embed.fields.find(f => f.name === 'Reported by');
+    if (!reportersField) throw new Error('No owner for this report');
+    const reasonField = embed.fields.find(f => f.name == 'Rules');
+    const statusField = embed.fields.find(f => f.name == 'Status');
+    const reportIdField = embed.fields.find(f => f.name === 'ID');
+    const contentField = embed.fields.find(f => f.name === 'Content');
+    const linkField = embed.fields.find(f => f.name === 'Context link');
+    const userIdField = embed.fields.find(f => f.name === 'User ID');
+
+    signalers = [];
+
+    reporterList = reportersField.value.split('|');
+    reporterList.forEach((element) => {
+        const id = parseId(element);
+        signalers.push(id);
+    });
+
+    return {
+        id: reportIdField?.value,
+        guildId: message.guild.id,
+        ownerId: signalers[0],
+        reportedUserId: parseId(userIdField?.value),
+        reportedContent: {
+            link: linkField?.value,
+            content: contentField?.value,
+            message: {
+                id: messageId.value
+            }
+        },
+        signalersId: signalers,
+        status: statusField?.value,
+        reason: reasonField?.value,
+        investigationId: message.id,
+        threadId: message.channel.id
+    };
+}
+
+function parseId(string) {
+    const match = string.match(/<@([0-9]*)>/);
+    return match[1];
+}

--- a/src/userCases.js
+++ b/src/userCases.js
@@ -8,18 +8,9 @@ class UserCase {
 }
   
 module.exports = {
-    async getOrCreateCase(client, guild, user, embed, components, reason) {
-        alerts = await db.getAlerts(guild.id);
-        alert = alerts.find(a => a.serverId == guild.id);
-        if (alert) {
-            channelId = alert.channelId;
-        } else {
-            channelId = "880186175057444914";
-        }
-
-        channel = await client.guilds.cache.get(guild.id).channels.fetch(channelId);
-
-        thread = await findThreadCase(channel, user);
+    async createCase(client, guild, user, embed, components, reason) {
+        const channel = await this.getChannelForCases(client, guild);
+        const thread = await this.findThreadCase(channel, user);
 
         if (thread) {
             await thread.setArchived(false);
@@ -33,22 +24,45 @@ module.exports = {
         pinCase(userCase);
 
         return userCase;
+    },
+    async modifyCase(message, embed, components) {
+        await message.delete();
+        const thread = message.channel;
+
+        // create a new case so mods get pinged again
+        const userCase = await createCaseOnThread(thread, embed, components);
+
+        // pin the latest case
+        pinCase(userCase);
+
+        return userCase;
+    },
+
+    async getChannelForCases(client, guild) {
+        alerts = await db.getAlerts(guild.id);
+        alert = alerts.find(a => a.serverId == guild.id);
+        if (!alert) {
+            throw 'No alert was setup.';
+        }
+        channelId = alert.channelId;
+
+        return await guild.channels.fetch(channelId);
+    },
+
+    async findThreadCase(channel, user) {
+        threadList = await channel.threads.fetch({
+            active: true
+        });
+    
+        return await threadList.threads.find(
+            thread => {
+                return thread.name.split(/ +/g).slice(-1)[0] === user.id;
+            }
+        );
     }
 }
 
 module.exports.UserCase = UserCase;
-
-async function findThreadCase(channel, user) {
-    threadList = await channel.threads.fetch({
-        active: true
-    });
-
-    return await threadList.threads.find(
-        thread => {
-            return thread.name.split(/ +/g).slice(-1)[0] === user.id;
-        }
-    );
-}
 
 async function createCaseOnThread(thread, embed, components) {
     await thread.setArchived(false);
@@ -65,13 +79,18 @@ async function createCaseOnThread(thread, embed, components) {
 }
 
 async function createThreadCase(channel, user, embed, components, reason) {
-    const thread = await channel.threads.create({
-        name: `${user.username.slice(0, 10)} ${user.id}`,
-        autoArchiveDuration: 1440,
-        reason: reason,
-      });
+    try {
+        const thread = await channel.threads.create({
+            name: `${user.username.slice(0, 10)} ${user.id}`,
+            autoArchiveDuration: 1440,
+            reason: reason,
+        });
 
-    return await createCaseOnThread(thread, embed, components);
+        return await createCaseOnThread(thread, embed, components);
+    } catch(e) {
+        console.log(`Couldn't create a thread on this server: ${e}`);
+        throw e;
+    }
 }
 
 async function pinCase(userCase) {

--- a/src/userCases.js
+++ b/src/userCases.js
@@ -1,0 +1,82 @@
+db = require('./db');
+
+class UserCase {
+    constructor(thread, message) {
+        this.thread = thread;
+        this.message = message;
+    }
+}
+  
+module.exports = {
+    async getOrCreateCase(client, guild, user, embed, components, reason) {
+        alerts = await db.getAlerts(guild.id);
+        alert = alerts.find(a => a.serverId == guild.id);
+        if (alert) {
+            channelId = alert.channelId;
+        } else {
+            channelId = "880186175057444914";
+        }
+
+        channel = await client.guilds.cache.get(guild.id).channels.fetch(channelId);
+
+        thread = await findThreadCase(channel, user);
+
+        if (thread) {
+            await thread.setArchived(false);
+
+            userCase = await createCaseOnThread(thread, embed, components);
+        } else {
+            userCase = await createThreadCase(channel, user, embed, components, reason);
+        }
+
+        // pin the latest case
+        pinCase(userCase);
+
+        return userCase;
+    }
+}
+
+module.exports.UserCase = UserCase;
+
+async function findThreadCase(channel, user) {
+    threadList = await channel.threads.fetch({
+        active: true
+    });
+
+    return await threadList.threads.find(
+        thread => {
+            return thread.name.split(/ +/g).slice(-1)[0] === user.id;
+        }
+    );
+}
+
+async function createCaseOnThread(thread, embed, components) {
+    await thread.setArchived(false);
+
+    const message = await thread.send({
+        content: '@here',
+        embeds: [embed],
+        components: components
+      });
+
+    // FIXME: add moderators to the thread
+
+    return new UserCase(thread, message);
+}
+
+async function createThreadCase(channel, user, embed, components, reason) {
+    const thread = await channel.threads.create({
+        name: `${user.username.slice(0, 10)} ${user.id}`,
+        autoArchiveDuration: 1440,
+        reason: reason,
+      });
+
+    return await createCaseOnThread(thread, embed, components);
+}
+
+async function pinCase(userCase) {
+    // fetch & unpin the latest pinned message
+    const pins = await userCase.thread.messages.fetchPinned();
+    if (pins.size >= 49) pins.last().unpin();
+    userCase.message.pin(true);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,6 +51,7 @@ const getDaysSince = (current, previous) => {
 }
 
 const collectCommandAnalytics = async (commandName, subCommandName) => {
+    return; // SHUT UP AND STOP BOTHERING ME WITH EVENTS.JS OH MY GOD JUST SHUT UP
     const updateAnalytics = (fileName, data) => {
         fs.writeFile(fileName, JSON.stringify(data, null, 2), function (err) {
             if (err) console.log('error', err);


### PR DESCRIPTION
From issue #102

Included most of the features from the issue. Since it's stateless (uses existing Discord message for finding and updating reports), the code is a bit messy and there may be a few issues.
I didn't introduce the feature that hides and then reinstate the reported message, I'm not sure if that would be what same actions as flagging means.
Currently there are 2 buttons for moderators: *Approve* and *Reject*, they only notify users who reported.
You can choose up to 3 rules (can be increased), but there are no implementation yet for non-community servers.

Users who will start reporting will have to wait 5 seconds before being able to report, during this time they are supposed to read the warning text. Afterwards the user can choose one or more rules from the dropdown list.

(Requires a lot of testing)