### PR TITLE
Few fixes for lazy-modmail

### DIFF
--- a/src/features/commands/buttons/modMessageApproveReport.js
+++ b/src/features/commands/buttons/modMessageApproveReport.js
@@ -9,19 +9,20 @@ module.exports = {
     type: 'button',
     description: 'Notify all reporters that this report is a valid one',
     async execute (client, interaction) {
+        await interaction.deferReply({ ephemeral: true });
+
         if (!interaction.member.permissions.serialize().KICK_MEMBERS) {
-            interaction.reply({
-                content: 'Insufficient permission to execute this command.'
+            interaction.editReply({
+                content: 'Insufficient permission to execute this command.',
             });
             return;
         }
-        interaction.deferUpdate();
 
         let reportData;
         try {
             reportData = await MessageReports.Storage.findByGeneratedReport(client, interaction.message);
         } catch(e) {
-            await interaction.reply({
+            await interaction.editReply({
                 content: e.message
             });
             return;
@@ -46,6 +47,10 @@ module.exports = {
         if (reportObject.thread) {
             await reportObject.thread.setArchived(true);
         }
+
+        interaction.editReply({
+            content: `Approved by ${interaction.member.toString()}`
+        });
     }
 };
 

--- a/src/features/commands/buttons/modMessageRejectReport.js
+++ b/src/features/commands/buttons/modMessageRejectReport.js
@@ -9,19 +9,20 @@ module.exports = {
     type: 'button',
     description: 'Reject and notify all reporters that no action will be taken',
     async execute (client, interaction) {
+        await interaction.deferReply({ ephemeral: true });
+
         if (!interaction.member.permissions.serialize().KICK_MEMBERS) {
-            interaction.reply({
-                content: 'Insufficient permission to execute this command.'
+            interaction.editReply({
+                content: 'Insufficient permission to execute this command.',
             });
             return;
         }
-        interaction.deferUpdate();
 
         let reportData;
         try {
             reportData = await MessageReports.Storage.findByGeneratedReport(client, interaction.message);
         } catch(e) {
-            await interaction.reply({
+            await interaction.editReply({
                 content: e.message
             });
             return;
@@ -45,6 +46,10 @@ module.exports = {
         if (reportObject.thread) {
             await reportObject.thread.setArchived(true);
         }
+    
+        interaction.editReply({
+            content: `Rejected by ${interaction.member.toString()}`
+        });
     }
 };
 


### PR DESCRIPTION
Using deferReply and editReply since fetching takes too long in **findByGeneratedReport**
Send a message in the report thread on approvement/rejection
Need to investigate why **findByGeneratedReport** triggers an exception as well (since the reply of the interaction failed inside the catch block)