### PR TITLE
Disable /poll in Microsoft Community

### DIFF
--- a/src/features/commands/poll.js
+++ b/src/features/commands/poll.js
@@ -61,6 +61,15 @@ module.exports = {
             return;
         }
 
+        if (interaction.guild.id === '150662382874525696') {
+            const ohSimusAsset = new MessageAttachment('./src/assets/images/ohsimus.png');
+            return interaction.reply({
+                content: 'Oh snap! This feature is currently disabled by the moderation team.',
+                files: [ohSimusAsset],
+                ephemeral: true
+            });
+        }
+
         switch (interaction.options._subcommand) {
             case "create":
                 const multipleAnswersAllowed = interaction.options.getBoolean('allow-multiple-answers', true);


### PR DESCRIPTION
I have not actually tested this code, but I did copy/paste it from another command into what seems like the most appropriate place, so I assume it's okay.
Decision to disable was made after a short discussion, the main concerns were the ability for people to spam the command in chat and the fact that we have never needed or would expect to need a way of creating polls.