### PR TITLE
Remove unnecessary allowed mentions

### DIFF
--- a/src/features/commands/premium.js
+++ b/src/features/commands/premium.js
@@ -57,8 +57,7 @@ module.exports = {
                             .setColor('#0099ff')
                             .setTitle('Dotsimus Reports')
                             .setDescription(`This channel has been setup for Dotsimus reports.`)
-                            .addField('Muted role', `<@&${role.id}>`, false)],
-                        allowedMentions: { parse: [] }
+                            .addField('Muted role', `<@&${role.id}>`, false)]
                     })
                     return interaction.reply({
                         content: "Configuration successful!",


### PR DESCRIPTION
Mentions in embeds won't ping anyone, so putting an allowed mentions field is totally unnecessary.